### PR TITLE
Migrate from SnoopPrecompile to PrecompileTools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,12 +6,12 @@ version = "0.1.0"
 [deps]
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 IfElse = "0.1.1"
-SnoopPrecompile = "1.0.1"
+PrecompileTools = "1.0.1"
 StaticArrays = "1.5.9"
 julia = "1"
 

--- a/src/PrimitiveCollisions.jl
+++ b/src/PrimitiveCollisions.jl
@@ -14,9 +14,9 @@ include("closest_pair.jl")
 include("utils.jl")
 include("prettyprinting.jl")
 
-import SnoopPrecompile
+import PrecompileTools
 
-SnoopPrecompile.@precompile_all_calls begin
+PrecompileTools.@compile_workload begin
     c1 = Circle(1.0)
     r1 = Rect(1.0, 1.0)
 


### PR DESCRIPTION
This pull request migrates the package from [SnoopPrecompile](https://github.com/timholy/SnoopCompile.jl/tree/master/SnoopPrecompile) to [PrecompileTools](https://github.com/JuliaLang/PrecompileTools.jl).
PrecompileTools is **nearly a drop-in replacement** except that there are **changes in naming and how developers locally disable precompilation** (to make their development workflow more efficient). These changes are described in [PrecompileTool's enhanced documentation](https://julialang.github.io/PrecompileTools.jl/stable/), which also includes instructions for users on how to set up custom "Startup" packages, handling precompilation tasks that are not amenable to workloads, and tips for troubleshooting.

Why the new package? It meets several goals:

- The name "SnoopPrecompile" was easily confused with "SnoopCompile," a package designed for *analyzing* rather than *enacting* precompilation.
- SnoopPrecompile/PrecompileTools has become (directly or indirectly) a dependency for much of the Julia ecosystem, a trend that seems likely to grow with time. It makes sense to host it in a more central location than one developer's personal account.
- As Julia's own stdlibs migrate to become independently updateable (true for DelimitedFiles in Julia 1.9, with others anticipated for Julia 1.10), several of them would like to use PrecompileTools for high-quality precompilation. That requires making PrecompileTools its own "upgradable stdlib."
- We wanted to change the [use of Preferences](https://github.com/timholy/SnoopCompile.jl/issues/356) to make packages more independent of one another. Since this would have been a breaking change, it seemed like a good opportunity to fix other issues, too.

For more information and discussion, see this [discourse post](https://discourse.julialang.org/t/ann-snoopprecompile-precompiletools/97882).
